### PR TITLE
docs: add RustChain — Proof-of-Antiquity blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,3 +905,7 @@ Awesome/Repo List of the cryptocurrencies in the github.
 - https://github.com/cfromknecht/OZcoin
 - https://github.com/ArthurAnanda/ccxt-arbitrage-v1
 - [More...]
+
+## Blockchain Projects
+
+* [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain. Rewards vintage hardware (PowerPC G4, SPARC, 68K) for mining. AI agent economy with RTC tokens.


### PR DESCRIPTION
## What does this PR do?

Adds RustChain to the Blockchain Projects section.

## Why?

RustChain is a unique blockchain:
- **Proof-of-Antiquity**: Rewards vintage hardware (PowerPC G4, SPARC, 68K)
- Older hardware = higher mining multiplier
- **AI Agent Economy**: RTC tokens power agent interactions

## Changes made

Added to new section `## Blockchain Projects`:
```
* [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain. Rewards vintage hardware (PowerPC G4, SPARC, 68K) for mining. AI agent economy with RTC tokens.
```

## Related Issues

Part of bounty #2862 (Awesome Lists)