### PR TITLE
Add halal-coin-screening and halalcrypto-strategy-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,4 +905,6 @@ Awesome/Repo List of the cryptocurrencies in the github.
 - https://github.com/cfromknecht/OZcoin
 - https://github.com/ArthurAnanda/ccxt-arbitrage-v1
 - [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain. Rewards vintage hardware (PowerPC G4, SPARC, 68K) for mining. AI agent economy with RTC tokens.
+- [halal-coin-screening](https://github.com/trustdraft-app/halal-coin-screening) - AAOIFI-aligned cryptocurrency screening framework. 267 coins, four-gate methodology (riba / gharar / maysir / haram-sector), 0–100 halal score, JSON CLI. Python, MIT, zero dependencies.
+- [halalcrypto-strategy-framework](https://github.com/trustdraft-app/halalcrypto-strategy-framework) - Abstract strategy interfaces for halal, spot-only crypto trading. Pure Python protocols for tier configs, signal sources, risk engines, and executors — no proprietary signal logic. Companion to halal-coin-screening. MIT.
 - [More...]


### PR DESCRIPTION
Adding two MIT-licensed Python libraries that fill a gap in the awesome-cryptocurrency ecosystem — Sharia-compliance screening tooling.

### [halal-coin-screening](https://github.com/trustdraft-app/halal-coin-screening) (v2.0.0)
AAOIFI-aligned cryptocurrency screening framework. 267 coins screened against four gates (riba / gharar / maysir / haram-sector), with a 0–100 halal score and a JSON CLI (`halal-screen`). Zero runtime dependencies.

```bash
pip install halal-coin-screening
halal-screen bitcoin --score --pretty
```

### [halalcrypto-strategy-framework](https://github.com/trustdraft-app/halalcrypto-strategy-framework) (v0.1.0)
Abstract strategy interfaces for halal, spot-only crypto trading systems. Pure Python protocols for tier configurations, signal sources, risk engines, and executors. Spot-only by construction (`leverage = 1` is enforced in `__post_init__`). Companion to halal-coin-screening.

Both libraries are MIT, zero-dependency, type-checked. They are useful for anyone building a halal-compliant trading product or wanting to verify another product's screening claims.