### PR TITLE
Add SolvoHQ/web3-discover-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,4 +905,5 @@ Awesome/Repo List of the cryptocurrencies in the github.
 - https://github.com/cfromknecht/OZcoin
 - https://github.com/ArthurAnanda/ccxt-arbitrage-v1
 - [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain. Rewards vintage hardware (PowerPC G4, SPARC, 68K) for mining. AI agent economy with RTC tokens.
+- [SolvoHQ/web3-discover-data](https://github.com/SolvoHQ/web3-discover-data) - CC0 dataset of currently-claimable web3 airdrops (chain, cost-floor, risk flag, deadline, "last verified" date); refreshed daily via GitHub Actions. Public discovery site at https://web3-discover.vercel.app.
 - [More...]


### PR DESCRIPTION
Adds [SolvoHQ/web3-discover-data](https://github.com/SolvoHQ/web3-discover-data) to the **All List**.

What it is:
- CC0 dataset of currently-claimable web3 airdrops — per entry: chain, cost-floor, risk flag, deadline, "last verified" date, source links
- Refreshed daily via GitHub Actions; byte-identical mirror of the live JSON API
- Public discovery / front-end site at https://web3-discover.vercel.app

One-line addition matching the existing `- https://github.com/...` entries in the list.